### PR TITLE
Add Microsoft TrueType Core/Web Fonts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ MAINTAINER aleksey.kolyadin@isobar.ru
 
 RUN apk add --no-cache poppler-utils
 
+# Add standard microsoft webfonts: https://packages.debian.org/sid/ttf-mscorefonts-installer
+# Fixes pdf conversion issues where no substitute fonts can be found. For example: "Syntax Error: Couldn't find a font for 'Helvetica'".
+RUN apk add --no-cache msttcorefonts-installer && update-ms-fonts 2>&1 && fc-cache -f
+
 RUN set -x ; \
   addgroup -g 82 -S www-data ; \
   adduser -u 82 -D -S -G www-data www-data && exit 0 ; exit 1


### PR DESCRIPTION
This fixes an error when converting a PDF and no valid substitute font exists. This specifically fixes 'Helvetica' and 'Helvetica Bold' but it should provide substitute fonts for a wide variety of other fonts.

For more information: https://packages.debian.org/sid/ttf-mscorefonts-installer

Resolves #1